### PR TITLE
fixed settings link pic on home page appearing as sock puppet on init…

### DIFF
--- a/src/Pages/HomePage.js
+++ b/src/Pages/HomePage.js
@@ -39,10 +39,12 @@ export default function HomePage() {
 
   //Pull user data
   useEffect(() => {
+    auth.authStateReady().then(() => {
     const user = auth.currentUser;
     if (user !== null) {
       setProfilePicture(user.photoURL);
     }
+  });
   }, []);
 
   useEffect(() => {

--- a/src/Pages/SettingsPage.js
+++ b/src/Pages/SettingsPage.js
@@ -237,6 +237,11 @@ export default function SettingsPage() {
               document.getElementById("delete_modal").showModal()
             }
           />
+          
+          <br />
+          <div className = 'flex flex-row text-xs'><p className = 'font-bold text-center'>Email:&nbsp;</p> {email}</div>
+          <div className = 'flex flex-row text-xs'><p className = 'font-bold text-center'>Pair Key:&nbsp;</p> {pairKey}</div>
+
           <dialog id="delete_modal" className="modal ">
             <div className="modal-box bg-slate-100">
               <form method="dialog">


### PR DESCRIPTION
1)WAS: settings link pic on home page appearing as sock puppet on initial load(supposed to be the logged in user's profile pic)
IS: Fixed to appear as the logged in user's pic correctly
2)Added email and pair key display to settings page